### PR TITLE
Change to the last opened workspace feature

### DIFF
--- a/src/KeybindManager.cpp
+++ b/src/KeybindManager.cpp
@@ -1,6 +1,7 @@
 #include "KeybindManager.hpp"
 #include "utilities/Util.hpp"
 #include "events/events.hpp"
+#include "windowManager.hpp"
 
 #include <algorithm>
 #include <string.h>
@@ -157,9 +158,13 @@ void KeybindManager::changeworkspace(std::string arg) {
 
     if (ID != -1) {
         Debug::log(LOG, "Changing the current workspace to " + std::to_string(ID));
-
         g_pWindowManager->changeWorkspaceByID(ID);
     }
+}
+
+void KeybindManager::changetolastworkspace(std::string arg) {
+    Debug::log(LOG, "Changing the current workspace to the last workspace");
+    g_pWindowManager->changeToLastWorkspace();
 }
 
 void KeybindManager::toggleActiveWindowFullscreen(std::string unusedArg) {

--- a/src/KeybindManager.hpp
+++ b/src/KeybindManager.hpp
@@ -23,6 +23,7 @@ namespace KeybindManager {
     void                movewindow(std::string args);
     void                movefocus(std::string args);
     void                changeworkspace(std::string args);
+    void                changetolastworkspace(std::string args);
     void                toggleActiveWindowFullscreen(std::string args);
     void                toggleActiveWindowFloating(std::string args);
     void                movetoworkspace(std::string args);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -119,6 +119,7 @@ void handleBind(const std::string& command, const std::string& value) {
     if (HANDLER == "movefocus") dispatcher = KeybindManager::movefocus;
     if (HANDLER == "movetoworkspace") dispatcher = KeybindManager::movetoworkspace;
     if (HANDLER == "workspace") dispatcher = KeybindManager::changeworkspace;
+    if (HANDLER == "lastworkspace") dispatcher = KeybindManager::changetolastworkspace;
     if (HANDLER == "togglefloating") dispatcher = KeybindManager::toggleActiveWindowFloating;
 
     if (dispatcher && KEY != 0)

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -1667,6 +1667,12 @@ void CWindowManager::changeWorkspaceByID(int ID) {
         QueuedPointerWarp = Vector2D(MONITOR->vecPosition + MONITOR->vecSize / 2.f);
 
     // no need for the new dirty, it's empty
+
+    lastActiveWorkspaceID = ID;
+}
+
+void CWindowManager::changeToLastWorkspace() {
+    changeWorkspaceByID(lastActiveWorkspaceID);
 }
 
 void CWindowManager::focusOnWorkspace(const int& work) {

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -1617,6 +1617,7 @@ void CWindowManager::changeWorkspaceByID(int ID) {
 
     // save old workspace for anim
     auto OLDWORKSPACE = activeWorkspaces[MONITOR->ID];
+    lastActiveWorkspaceID = OLDWORKSPACE;
 
     for (auto& workspace : workspaces) {
         if (workspace.getID() == ID) {
@@ -1667,8 +1668,6 @@ void CWindowManager::changeWorkspaceByID(int ID) {
         QueuedPointerWarp = Vector2D(MONITOR->vecPosition + MONITOR->vecSize / 2.f);
 
     // no need for the new dirty, it's empty
-
-    lastActiveWorkspaceID = ID;
 }
 
 void CWindowManager::changeToLastWorkspace() {

--- a/src/windowManager.hpp
+++ b/src/windowManager.hpp
@@ -47,6 +47,7 @@ public:
 
     std::deque<CWorkspace>      workspaces;
     std::deque<int>             activeWorkspaces;
+    int                         lastActiveWorkspaceID = 1;
 
     // Pipes
     SIPCPipe                    m_sIPCBarPipeIn = {ISDEBUG ? "/tmp/hypr/hyprbarind" : "/tmp/hypr/hyprbarin", 0};
@@ -90,6 +91,7 @@ public:
     void                        recalcAllDocks();
 
     void                        changeWorkspaceByID(int);
+    void                        changeToLastWorkspace();
     void                        setAllWorkspaceWindowsDirtyByID(int);
     int                         getHighestWorkspaceID();
     CWorkspace*                 getWorkspaceByID(int);


### PR DESCRIPTION
### Done tasks:
- [x] Create everything needed for the feature (including definitions and methods).
- [x] Reuse the codes from `CWindowManager::changeWorkspaceByID` method.
### Bugs:
- False behavior when switching from the workspace that has windows opened and the one that don't have any windows.
- **Question about the bug**: I don't know if that's because my own logic bugs or there are some parts implicitly included in your code. (very likely that I missed some implemented ideas of the reused method)
### TODO:
- Fix the bug and ready for a complete PR.