### PR TITLE
Disable round corners when in pseudo-fullscreen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 all: cmake
 
 release:
-	mkdir build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -H./ -B./build -G Ninja
+	mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -H./ -B./build -G Ninja
 	cmake --build ./build --config Release --target all -j 10
 
 debug:
-	mkdir build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -H./ -B./build -G Ninja
+	mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -H./ -B./build -G Ninja
 	cmake --build ./build --config Debug --target all -j 10
 
 clear:

--- a/src/windowManager.cpp
+++ b/src/windowManager.cpp
@@ -765,7 +765,7 @@ void CWindowManager::applyShapeToWindow(CWindow* pWindow) {
     if (!pWindow)
         return;
 
-    const auto ROUNDING = pWindow->getFullscreen() ? 0 : ConfigManager::getInt("rounding");
+    const auto ROUNDING = pWindow->getFullscreen() || (ConfigManager::getInt("layout:no_gaps_when_only") && getWindowsOnWorkspace(pWindow->getWorkspaceID()) == 1) ? 0 : ConfigManager::getInt("rounding");
 
     const auto SHAPEQUERY = xcb_get_extension_data(DisplayConnection, &xcb_shape_id);
 


### PR DESCRIPTION
An addition to no gaps and borders when a window is the only window on the screen