### PR TITLE
Added escaping of `{`, `}` and `$`

### DIFF
--- a/src/bar/BarCommands.cpp
+++ b/src/bar/BarCommands.cpp
@@ -158,17 +158,26 @@ std::string BarCommands::parseCommand(std::string command) {
         else if (c == '$') {
             // find the next one
             for (long unsigned int j = i + 1; i < command.length(); ++j) {
-                if (command[j] == '$') {
+                if (command[j] == '$' && command[j - 1] != '\\') {
                     // found!
-                    auto toSend = command.substr(i + 1);
-                    toSend = toSend.substr(0, toSend.find_first_of('$'));
-                    result += parseDollar(toSend);
+                    auto toSend = command.substr(i + 1, j - (i + 1));
+                    std::string toSendWithRemovedEscapes = "";
+                    for (std::size_t k = 0; k < toSend.length(); ++k) {
+                        if (toSend[k] == '\\' && (k + 1) < toSend.length()) {
+                            char next = toSend[k + 1];
+                            if (next == '$' || next == '{' || next == '}') {
+                                continue;
+                            }
+                        } 
+                        toSendWithRemovedEscapes += toSend[k];
+                    }
+                    result += parseDollar(toSendWithRemovedEscapes);
                     i = j;
                     break;
                 }
 
                 if (j + 1 == command.length()) {
-                    Debug::log(ERR, "Unescaped $ in a module, module command: ");
+                    Debug::log(ERR, "Unpaired $ in a module, module command: ");
                     Debug::log(NONE, command);
                 }
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -285,7 +285,9 @@ void parseLine(std::string& line) {
         return;
     }
 
-    if (line.find("}") != std::string::npos && ConfigManager::currentCategory != "") {
+    std::size_t closingBrace = line.find("}");
+    if (closingBrace != std::string::npos && ConfigManager::currentCategory != "" &&
+            (closingBrace == 0 || line[closingBrace - 1] != '\\')) {
         ConfigManager::currentCategory = "";
         return;
     }


### PR DESCRIPTION
This PR adds escaping of special symbols.

It's not currently possible to use `$`, `{` or `}` inside `$COMMANDTOKEN$`s, which is what this PR fixes. Whenever the parser encounters one of these symbols, it checks whether a `\` precedes them, and if that is true, it treats those symbols literally.

A couple caveats:
- The parser doesn't check whether `{` is actually escaped, since you require it to be preceded by a space anyway.
- However, if a `{` is escaped inside a command token, the backslash is removed.
- No backslashes are removed anywhere but command tokens, even though escaped characters are treated as such. But I can't see a use for escaping characters outside command tokens, so it's probably fine.