### PR TITLE
Fixed bar module width

### DIFF
--- a/src/bar/Bar.cpp
+++ b/src/bar/Bar.cpp
@@ -420,7 +420,7 @@ int CStatusBar::getTextWidth(std::string text, std::string font, double size) {
     cairo_text_extents_t textextents;
     cairo_text_extents(m_pCairo, text.c_str(), &textextents);
    
-    return textextents.width + 1 /* pad */;
+    return textextents.x_advance;
 }
 
 void CStatusBar::drawText(Vector2D pos, std::string text, uint32_t color, std::string font, double size) {


### PR DESCRIPTION
`CStatusBar::getTextWidth` does not respect whitespace symbols at the start or the end of modules, this PR fixes this.

As an example, for `module=center,foo,0xffffffff,0xff000000,1000, bar` (note the space before "bar"):
Before: 
![image](https://user-images.githubusercontent.com/31628566/170226254-fc1ee3b0-63ad-4f07-85fc-e105d1cec1ed.png)
After:
![image](https://user-images.githubusercontent.com/31628566/170226309-61ecca1b-ab6a-4ebd-bfea-2b9a015bb827.png)

