### PR TITLE
potential risk for double free

### DIFF
--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -71,8 +71,6 @@
         free(name);                          \
         return;                              \
     }                                        \
-    free(error##name);
-
 
 #define VECTORDELTANONZERO(veca, vecb) (abs(veca.x - vecb.x) > 0.4f || abs(veca.y - vecb.y) > 0.4f)
 #define VECTORDELTAMORETHAN(veca, vecb, delta) (abs(veca.x - vecb.x) > (delta) || abs(veca.y - vecb.y) > (delta))


### PR DESCRIPTION
already free becaus of prior `error##name != NULL `
assuming this condition is adequate to not free a second time
--- from https://cwe.mitre.org/data/definitions/415.html
Ensure that each allocation is freed only once. After freeing a chunk, set the pointer to NULL to ensure the pointer cannot be freed again. In complicated error conditions, be sure that clean-up routines respect the state of allocation properly. If the language is object oriented, ensure that object destructors delete each chunk of memory only once. 